### PR TITLE
dont throw error when there is no element.

### DIFF
--- a/addon/components/bm-select.js
+++ b/addon/components/bm-select.js
@@ -157,7 +157,7 @@ export default Em.Component.extend({
       Em.run.later(this, function() {
         var focussedElement = document.activeElement;
         var target = this.$();
-        if (target.length) {
+        if (target) {
           var isFocussedOut = target.has(focussedElement).length === 0 && !this.$().is(focussedElement);
 
           if(isFocussedOut) {

--- a/addon/components/bm-select.js
+++ b/addon/components/bm-select.js
@@ -158,7 +158,7 @@ export default Em.Component.extend({
         var focussedElement = document.activeElement;
         var target = this.$();
         if (target) {
-          var isFocussedOut = target.has(focussedElement).length === 0 && !this.$().is(focussedElement);
+          var isFocussedOut = target.has(focussedElement).length === 0 && !target.is(focussedElement);
 
           if(isFocussedOut) {
             this.closeOptions({focus:false});

--- a/addon/components/bm-select.js
+++ b/addon/components/bm-select.js
@@ -156,10 +156,13 @@ export default Em.Component.extend({
     if(this.get('isOpen')) {
       Em.run.later(this, function() {
         var focussedElement = document.activeElement;
-        var isFocussedOut = this.$().has(focussedElement).length === 0 && !this.$().is(focussedElement);
+        var target = this.$();
+        if (target.length) {
+          var isFocussedOut = target.has(focussedElement).length === 0 && !this.$().is(focussedElement);
 
-        if(isFocussedOut) {
-          this.closeOptions({focus:false});
+          if(isFocussedOut) {
+            this.closeOptions({focus:false});
+          }
         }
       }, 0);
     }


### PR DESCRIPTION
Since this uses "run.later", sometimes the element has been destroyed when this function runs. So, ".has" will throw an error -- it was actually breaking my CI tests earlier and I just ran into it again when I was trying to add some async error handling.