### PR TITLE
substitute reference to parentView with call to this.nearestOfType

### DIFF
--- a/addon/components/bm-option.js
+++ b/addon/components/bm-option.js
@@ -1,5 +1,6 @@
 import Em from 'ember';
-
+import BmSelect from './bm-select';
+import BmOptions from './bm-options';
 
 /**
    * Observe the passed in selected value in the BmSelect component and update
@@ -97,7 +98,9 @@ export default Em.Component.extend({
    * @property select
    * @type BmSelect
    */
-  select: Em.computed.alias('parentView.parentView'),
+  select: Em.computed(function(){
+    return this.nearestOfType(BmSelect);
+  }),
 
   /**
    * Reference to the BmOptionsComponent instance.
@@ -105,7 +108,9 @@ export default Em.Component.extend({
    * @property options
    * @type BmOptions
    */
-  options: Em.computed.alias('parentView'),
+  options: Em.computed(function(){
+    return this.nearestOfType(BmOptions);
+  }),
 
   /**
    * The index of this option in the BmOptionsComponent instance.

--- a/addon/components/bm-options.js
+++ b/addon/components/bm-options.js
@@ -1,4 +1,5 @@
 import Em from 'ember';
+import BmSelect from './bm-select';
 
 export default Em.Component.extend({
 
@@ -26,7 +27,7 @@ export default Em.Component.extend({
    * @property isVisible
    * @type Boolean
    */
-  isVisible: Em.computed.alias('parentView.isOpen'),
+  isVisible: Em.computed.alias('select.isOpen'),
 
   /**
    * Reference to the BmSelectComponent instance.
@@ -34,7 +35,9 @@ export default Em.Component.extend({
    * @property select
    * @type BmSelect
    */
-  select: Em.computed.alias('parentView'),
+  select: Em.computed(function(){
+    return this.nearestOfType(BmSelect);
+  }),
 
   /**
    * Reference to the selected BmOptionComponent instance.
@@ -42,7 +45,7 @@ export default Em.Component.extend({
    * @property selectedOption
    * @type BmOption
    */
-  selectedOption: Em.computed.alias('parentView.selectedOption'),
+  selectedOption: Em.computed.alias('select.selectedOption'),
 
   /**
    * Storage for all BmOption components, facilitating keyboard navigation.


### PR DESCRIPTION
In Ember 1.13 property  `parentView` is removed, so component is broken in Ember 1.13+. This PR substitutes references to `parentView` property to access parent components and uses `this.nearestOfType` method (more about it [here](http://emberjs.com/api/classes/Ember.Component.html#method_nearestOfType)). 
